### PR TITLE
Added error handling for empty respone

### DIFF
--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -39,17 +39,20 @@ def __execute_rpc__(device, rpc_command, timeout):
     root = ET.fromstring(response)
     childs = [x.tag for x in list(root)]
 
-    if int(root.find('ResultSummary').get('ErrorCount')) > 0:
+    try:
+        if int(root.find('ResultSummary').get('ErrorCount')) > 0:
 
-        if 'CLI' in childs:
-            error_msg = root.find('CLI').get('ErrorMsg') or ''
-        elif 'Commit' in childs:
-            error_msg = root.find('Commit').get('ErrorMsg') or ''
-        else:
-            error_msg = root.get('ErrorMsg') or ''
+            if 'CLI' in childs:
+                error_msg = root.find('CLI').get('ErrorMsg') or ''
+            elif 'Commit' in childs:
+                error_msg = root.find('Commit').get('ErrorMsg') or ''
+            else:
+                error_msg = root.get('ErrorMsg') or ''
 
-        error_msg += '\nOriginal call was: %s' % rpc_command
-        raise XMLCLIError(error_msg)
+            error_msg += '\nOriginal call was: %s' % rpc_command
+            raise XMLCLIError(error_msg)
+    except AttributeError:
+        raise XMLCLIError('Empty response')
 
     if 'CLI' in childs:
         cli_childs = [x.tag for x in list(root.find('CLI'))]


### PR DESCRIPTION
When you are not allowing iteration on your ios-xr router and try to execute a rpc command you get an empty response this previously caused the following stack trace

Traceback (most recent call last):
  File "count_bgp_table.py", line 30, in <module>
    derp = dev.device.make_rpc_call(rpc_command)
  File "/home/loke/.virtualenvs/napalm/local/lib/python2.7/site-packages/pyIOSXR/iosxr.py", line 119, in make_rpc_call
    result = **execute_rpc**(self.device, rpc_command, self.timeout)
  File "/home/loke/.virtualenvs/napalm/local/lib/python2.7/site-packages/pyIOSXR/iosxr.py", line 42, in **execute_rpc**
    if int(root.find('ResultSummary').get('ErrorCount')) > 0:
AttributeError: 'NoneType' object has no attribute 'get'

It will now yield 

Traceback (most recent call last):
  File "count_bgp_table.py", line 30, in <module>
    derp = dev.device.make_rpc_call(rpc_command)
  File "/home/loke/.virtualenvs/napalm/local/lib/python2.7/site-packages/pyIOSXR/iosxr.py", line 121, in make_rpc_call
    result = **execute_rpc**(self.device, rpc_command, self.timeout)
  File "/home/loke/.virtualenvs/napalm/local/lib/python2.7/site-packages/pyIOSXR/iosxr.py", line 54, in **execute_rpc**
    raise XMLCLIError('Empty response')
pyIOSXR.exceptions.XMLCLIError: Empty response
