### PR TITLE
add function commit_config_with_label

### DIFF
--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -207,20 +207,17 @@ class IOSXR:
 
         return ''.join(diff.splitlines(1)[2:-2])
 
-    def commit_config(self):
+    def commit_config(self, label=None, comment=None):
         """
         Commits the candidate config to the device, by merging it with the
         existing one.
         """
-        rpc_command = '<Commit/>'
-        response = __execute_rpc__(self.device, rpc_command, self.timeout)
-
-    def commit_config_with_label(self,label,comment):
-        """
-        Commits the candidate config to the device, by merging it with the
-        existing one.  Includes a user defined commit label & comment
-        """
-        rpc_command = '<Commit Label="'+label+'" Comment="'+comment+'"/>'
+        rpc_command = '<Commit'
+        if label: 
+            rpc_command += ' Label="' + label + '"'
+        if comment: 
+            rpc_command += ' Comment="' + comment + '"'
+        rpc_command += '/>'
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 
     def commit_replace_config(self):

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -215,6 +215,14 @@ class IOSXR:
         rpc_command = '<Commit/>'
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 
+    def commit_config_with_label(self,label,comment):
+        """
+        Commits the candidate config to the device, by merging it with the
+        existing one.  Includes a user defined commit label & comment
+        """
+        rpc_command = '<Commit Label="'+label+'" Comment="'+comment+'"/>'
+        response = __execute_rpc__(self.device, rpc_command, self.timeout)
+
     def commit_replace_config(self):
         """
         Commits the candidate config to the device, by replacing the existing

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -214,9 +214,9 @@ class IOSXR:
         """
         rpc_command = '<Commit'
         if label: 
-            rpc_command += ' Label="' + label + '"'
+            rpc_command += ' Label="%s"' % label
         if comment: 
-            rpc_command += ' Comment="' + comment + '"'
+            rpc_command += ' Comment="%s"' % comment
         rpc_command += '/>'
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 


### PR DESCRIPTION
I'd like to add the ability to do commits with labels.  My network uses this feature heavily.  I created a new function to add commit label and commit comments.  I'm not a programmer so it likely needs some clean up.  It did work in my lab.  Thanks.
