### PR TITLE
Ability to add communication logging in pexpect and adding commit label and comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Call close() to close the connection to the device:
 ```
 
 ### Debugging Connection
-Added posibillity to create a logfile of the communication between pyIOSXR and the router.
+create a logfile of the communication between pyIOSXR and the router.
 ```python
 >>> from pyIOSXR import IOSXR
 >>> import sys

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ call commit_replace_config():
 ```python
 >>> device.load_candidate_config(filename='unit/test/full_config.txt')
 >>> device.compare_replace_config()
->>> device.commit_replace_config(comment='comment saved to device', label='label')
+>>> device.commit_replace_config(label='my label', comment='my comment')
 ```
 
 ### Rollback Config

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ call discard_config():
 ### Load, Compare and Merge Config
 If you want to commit the loaded configuration and merge it with the existing 
 configuration, call commit_config():
+(comment and label is optional parameters)
 ```python
 >>> device.load_candidate_config(filename='unit/test/other_config.txt')
 >>> device.compare_config()
@@ -61,16 +62,17 @@ configuration, call commit_config():
 +interface TenGigE0/0/0/21
 + description testing-xml-from-the-other-file
 +!
->>> device.commit_config()
+>>> device.commit_config(comment='comment saved on device', label='label')
 ```
 
 ### Commit Replace Config
 If you would rather commit the config by replacing the existing configuration,
 call commit_replace_config():
+(comment and label is optional parameters)
 ```python
 >>> device.load_candidate_config(filename='unit/test/full_config.txt')
 >>> device.compare_replace_config()
->>> device.commit_replace_config()
+>>> device.commit_replace_config(comment='comment saved to device', label='label')
 ```
 
 ### Rollback Config
@@ -102,6 +104,22 @@ Call close() to close the connection to the device:
 ```python
 >>> device.close()
 ```
+
+### Debugging Connection
+Added posibillity to create a logfile of the communication between pyIOSXR and the router.
+```python
+>>> from pyIOSXR import IOSXR
+>>> import sys
+>>> device=IOSXR(hostname="router", username="cisco", password="cisco", port=22, timeout=120, logfile=sys.stdout)
+
+OR
+
+>>> from pyIOSXR import IOSXR
+>>> import sys
+>>> file = open("logfile.log")
+>>> device=IOSXR(hostname="router", username="cisco", password="cisco", port=22, timeout=120, logfile=file)
+```
+
 
 Thanks
 ======

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ configuration, call commit_config():
 >>> device.commit_config(comment='comment saved on device', label='label')
 ```
 
+### Merge Config with Timer based autorollback
+If you want to commit the loaded configuration with a timed autorollback that
+needs to be confirmed use the confirmed= keyword on the commit, parameters is
+seconds to wait before autorollback, values from 30 to 300sec.
+when using confirmed= you need to do another commit_config() without parameters
+within the time spesified to acknowledge the commit or else it rolls back your changes.
+(comment and label is optional parameters)
+```python
+>>> device.load_candidate_config(filename='unit/test/other_config.txt')
+>>> device.commit_config(comment='comment saved on device', label='label', confirmed=30)
+.... Code to do checks etc ....
+>>> device.commit_config()
+```
+
 ### Commit Replace Config
 If you would rather commit the config by replacing the existing configuration,
 call commit_replace_config():

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ within the time spesified to acknowledge the commit or else it rolls back your c
 (comment and label is optional parameters)
 ```python
 >>> device.load_candidate_config(filename='unit/test/other_config.txt')
->>> device.commit_config(comment='comment saved on device', label='label', confirmed=30)
+>>> device.commit_config(label='my label', comment='my comment', confirmed=30)
 .... Code to do checks etc ....
 >>> device.commit_config()
 ```

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -250,7 +250,7 @@ class IOSXR:
         :param label:     User label saved on this commit on the device
         :param confirmed: Commit with auto-rollback if new commit is not made in 30 to 300 sec
         """
-       rpc_command = '<Commit Replace="true"'
+        rpc_command = '<Commit Replace="true"'
         if label:
             rpc_command += ' Label="%s"' % label
         if comment:

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -250,15 +250,16 @@ class IOSXR:
         :param label:     User label saved on this commit on the device
         :param confirmed: Commit with auto-rollback if new commit is not made in 30 to 300 sec
         """
-        params = ''
-        if comment: params += ' Comment="%s"' % comment
-        if label:   params += ' Label="%s"' % label
-        if confirmed: 
+       rpc_command = '<Commit Replace="true"'
+        if label:
+            rpc_command += ' Label="%s"' % label
+        if comment:
+            rpc_command += ' Comment="%s"' % comment
+        if confirmed:
             if 30 <= int(confirmed) <= 300:
-                params += ' Confirmed="%d"' % int(confirmed)
-            else: raise InvalidInputError('confirmed needs to be between 30 and 300') 
-
-        rpc_command = '<Commit Replace="true"%s/>' % params
+                rpc_command += ' Confirmed="%d"' % int(confirmed)
+            else: raise InvalidInputError('confirmed needs to be between 30 and 300')
+        rpc_command += '/>'
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 
     def discard_config(self):

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -88,6 +88,7 @@ class IOSXR:
         :param password:  Password
         :param port:      SSH Port (default: 22)
         :param timeout:   Timeout (default: 60 sec)
+        :param logfile:   File-like object to save device communication to or None to disable logging
         """
         self.hostname = hostname
         self.username = username
@@ -214,6 +215,10 @@ class IOSXR:
         """
         Commits the candidate config to the device, by merging it with the
         existing one.
+        
+        :param comment:   User comment saved on this commit on the device
+        :param label:     User label saved on this commit on the device
+        :param confirmed: Commit with auto-rollback if new commit is not made in 30 to 300 sec
         """
         params = ''
         if comment: params += ' Comment="%s"' % comment
@@ -230,6 +235,10 @@ class IOSXR:
         """
         Commits the candidate config to the device, by replacing the existing
         one.
+        
+        :param comment:   User comment saved on this commit on the device
+        :param label:     User label saved on this commit on the device
+        :param confirmed: Commit with auto-rollback if new commit is not made in 30 to 300 sec
         """
         params = ''
         if comment: params += ' Comment="%s"' % comment

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -26,7 +26,9 @@ def __execute_rpc__(device, rpc_command, timeout):
     rpc_command = '<?xml version="1.0" encoding="UTF-8"?><Request MajorVersion="1" MinorVersion="0">'+rpc_command+'</Request>'
     try:
         device.sendline(rpc_command)
-        device.expect_exact("</Response>", timeout = timeout)
+        index = device.expect_exact(["</Response>","ERROR: 0xa240fe00"], timeout = timeout)
+        if index == 1:
+            raise XMLCLIError('The XML document is not well-formed')
     except pexpect.TIMEOUT as e:
         raise TimeoutError("pexpect timeout error")
     except pexpect.EOF as e:

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -77,7 +77,7 @@ def __execute_config_show__(device, show_command, timeout):
 
 class IOSXR:
 
-    def __init__(self, hostname, username, password, port=22, timeout=60):
+    def __init__(self, hostname, username, password, port=22, timeout=60, logfile=None):
         """
         A device running IOS-XR.
 
@@ -92,6 +92,7 @@ class IOSXR:
         self.password = password
         self.port     = port
         self.timeout  = timeout
+        self.logfile  = logfile
 
     def __getattr__(self, item):
         """
@@ -123,7 +124,7 @@ class IOSXR:
         """
         Opens a connection to an IOS-XR device.
         """
-        device = pexpect.spawn('ssh -o ConnectTimeout={} -p {} {}@{}'.format(self.timeout, self.port, self.username, self.hostname))
+        device = pexpect.spawn('ssh -o ConnectTimeout={} -p {} {}@{}'.format(self.timeout, self.port, self.username, self.hostname), logfile=self.logfile)
         try:
             index = device.expect(['\(yes\/no\)\?', 'password:', pexpect.EOF], timeout = self.timeout)
             if index == 0:

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -208,20 +208,28 @@ class IOSXR:
 
         return ''.join(diff.splitlines(1)[2:-2])
 
-    def commit_config(self):
+    def commit_config(self, comment=None, label=None):
         """
         Commits the candidate config to the device, by merging it with the
         existing one.
         """
-        rpc_command = '<Commit/>'
+        params = ''
+        if comment: params += ' Comment="%s"' % comment
+        if label:   params += ' Label="%s"' % label
+   
+        rpc_command = '<Commit%s/>' % params
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 
-    def commit_replace_config(self):
+    def commit_replace_config(self, comment=None, label=None):
         """
         Commits the candidate config to the device, by replacing the existing
         one.
         """
-        rpc_command = '<Commit Replace="true"/>'
+        params = ''
+        if comment: params += ' Comment="%s"' % comment
+        if label:   params += ' Label="%s"' % label
+   
+        rpc_command = '<Commit Replace="true"%s/>' % params
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 
     def discard_config(self):

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -208,7 +208,7 @@ class IOSXR:
 
         return ''.join(diff.splitlines(1)[2:-2])
 
-    def commit_config(self, comment=None, label=None):
+    def commit_config(self, comment=None, label=None, confirmed=None):
         """
         Commits the candidate config to the device, by merging it with the
         existing one.
@@ -216,11 +216,15 @@ class IOSXR:
         params = ''
         if comment: params += ' Comment="%s"' % comment
         if label:   params += ' Label="%s"' % label
-   
+        if confirmed: 
+            if 30 <= int(confirmed) <= 300: 
+                params += ' Confirmed="%d"' % int(confirmed)
+            else: raise InvalidInputError('confirmed needs to be between 30 and 300') 
+
         rpc_command = '<Commit%s/>' % params
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 
-    def commit_replace_config(self, comment=None, label=None):
+    def commit_replace_config(self, comment=None, label=None, confirmed=None):
         """
         Commits the candidate config to the device, by replacing the existing
         one.
@@ -228,7 +232,11 @@ class IOSXR:
         params = ''
         if comment: params += ' Comment="%s"' % comment
         if label:   params += ' Label="%s"' % label
-   
+        if confirmed: 
+            if 30 <= int(confirmed) <= 300:
+                params += ' Confirmed="%d"' % int(confirmed)
+            else: raise InvalidInputError('confirmed needs to be between 30 and 300') 
+
         rpc_command = '<Commit Replace="true"%s/>' % params
         response = __execute_rpc__(self.device, rpc_command, self.timeout)
 


### PR DESCRIPTION
Hi!

I added the ability to log all pexpect communications between pyIOSXR and the device.
needed this the first time i used this library because of syntax errors in my config that was not detected  by pyIOSXR.

I also added the ability to specify a commit comment and label when commit'ing to the device. this will be saved in the commit log on the device.

I've not added any input validation from the comments added by the user.
More information on Comments:
http://www.cisco.com/c/en/us/td/docs/ios_xr_sw/iosxr_r4-1/xml/programming/guide/xl41apidoc/xl41cnfg.html#wp1080472
