### PR TITLE
Added an expect match for Key auth.

### DIFF
--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -137,15 +137,16 @@ class IOSXR:
         """
         device = pexpect.spawn('ssh -o ConnectTimeout={} -p {} {}@{}'.format(self.timeout, self.port, self.username, self.hostname), logfile=self.logfile)
         try:
-            index = device.expect(['\(yes\/no\)\?', 'password:', pexpect.EOF], timeout = self.timeout)
+            index = device.expect(['\(yes\/no\)\?', 'password:', '#', pexpect.EOF], timeout = self.timeout)
             if index == 0:
                 device.sendline('yes')
-                index = device.expect(['\(yes\/no\)\?', 'password:', pexpect.EOF], timeout = self.timeout)
+                index = device.expect(['\(yes\/no\)\?', 'password:', '#', pexpect.EOF], timeout = self.timeout)
             if index == 1:
                 device.sendline(self.password)
-            elif index == 2:
+            elif index == 3:
                 pass
-            device.expect('#', timeout = self.timeout)
+            if index != 2:
+                device.expect('#', timeout = self.timeout)
             device.sendline('xml')
             index = device.expect(['XML>', 'ERROR: 0x24319600'], timeout = self.timeout)
             if index == 1:


### PR DESCRIPTION
It's not perfect, since it only matches on '#', instead of matching on something like 'RP/0/RSP0/CPU0:hostname#'. It's probably good enough, since line 149 already had this behavior, so this patch doesn't break any existing behavior. This could be improved though.

Fixes #15 
