### PR TITLE
Release the XML agent when closing

### DIFF
--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -356,6 +356,7 @@ class IOSXR(object):
         """
         if self.lock_on_connect or self.locked:
             self.unlock()
+        self._xml_agent_acquired = False
         self.device.remote_conn.close()
 
     def lock(self):


### PR DESCRIPTION
Not a detrimental change, just sometimes it is useful to make sure the XML agent is released on close.
