### PR TITLE
Rollback compare_config_show

### DIFF
--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -462,7 +462,10 @@ class IOSXR(object):
 
         :return:  Config diff.
         """
-        return self.compare_config()
+
+        diff = self._execute_config_show('show configuration changes diff')
+
+        return ''.join(diff.splitlines(1)[2:-2])
 
     def commit_config(self, label=None, comment=None, confirmed=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']
 reqs = [str(ir.req) for ir in install_reqs]
 
-version = '0.20'
+version = '0.21'
 
 setup(
     name='pyIOSXR',

--- a/test/mock/CLI_Configuration_show_configuration_changes_diffConfiguration_CLI_.xml
+++ b/test/mock/CLI_Configuration_show_configuration_changes_diffConfiguration_CLI_.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Response MajorVersion="1" MinorVersion="0"><CLI><Configuration>
+Building configuration...
+!! IOS XR Configuration version = 6.2.1.08I
+-  telnet vrf default ipv4 server max-servers 10
+-  username vagrant
+-   group root-lr
+-   group cisco-support
+-   secret 5 $1$gZpA$ued8wLDDwikqTVKTEvUe2/
+-  !
+-  tpa
+-   address-family ipv4
+-    update-source MgmtEth0/RP0/CPU0/0
+-   !
+-  !
+-  interface MgmtEth0/RP0/CPU0/0
+-   ipv4 address dhcp
+-  !
+-  interface GigabitEthernet0/0/0/0
+-   shutdown
+-  !
+-  interface GigabitEthernet0/0/0/1
+-   shutdown
+-  !
+-  interface GigabitEthernet0/0/0/2
+-   shutdown
+-  !
+-  interface GigabitEthernet0/0/0/3
+-   shutdown
+-  !
+-  router static
+-   address-family ipv4 unicast
+-    0.0.0.0/0 MgmtEth0/RP0/CPU0/0 10.0.2.2
+-   !
+-  !
+-  grpc
+-   port 57777
+-  xml agent tty
+-   iteration off
+-  !
+-  ssh server v2
+-  ssh server vrf default
+end
+
+</Configuration></CLI><ResultSummary ErrorCount="0"/></Response>
+XML>

--- a/test/test.py
+++ b/test/test.py
@@ -693,9 +693,7 @@ class TestIOSXRDevice(unittest.TestCase):
         """Helper method to be used in the config-replace tests below"""
 
         running_config = ''.join(self.device.show_run().splitlines(1)[3:])
-        print 'loading running config again'
         self.device.load_candidate_config(config=running_config)
-        print 'loaded'
         self.device.load_candidate_config(config='ntp server 8.8.8.8')
 
     def test_compare_replace_config(self):


### PR DESCRIPTION
Change to previous behaviour and execute `show configuration changes diff` to compare config when replace.
This method is not recommended however in prod environments, or in cases when the CPU usage is relatively high - the XML agent will throw `ERROR: 0x44318c06 'XML-TTY' detected the 'warning' condition 'A Light Weight Messaging library communication function returned an error': No such device or address` and exits.
