### PR TITLE
Fixes #55: Check commit comment length

### DIFF
--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -579,14 +579,17 @@ class IOSXR(object):
         Commit the candidate config.
 
         :param label:     Commit comment, displayed in the commit entry on the device.
-        :param comment:   Commit label, displayed instead of the commit ID on the device.
+        :param comment:   Commit label, displayed instead of the commit ID on the device. (Max 60 characters)
         :param confirmed: Commit with auto-rollback if new commit is not made in 30 to 300 sec
         """
         rpc_command = '<Commit'
         if label:
             rpc_command += ' Label="%s"' % label
         if comment:
-            rpc_command += ' Comment="%s"' % comment
+            if len(comment) <= 60:
+                rpc_command += ' Comment="%s"' % comment
+            else:
+                raise InvalidInputError('comment needs to be shorter than 60 characters', self)
         if confirmed:
             if 30 <= int(confirmed) <= 300:
                 rpc_command += ' Confirmed="%d"' % int(confirmed)

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -586,10 +586,7 @@ class IOSXR(object):
         if label:
             rpc_command += ' Label="%s"' % label
         if comment:
-            if len(comment) <= 60:
-                rpc_command += ' Comment="%s"' % comment
-            else:
-                raise InvalidInputError('comment should be no more than 60 characters', self)
+            rpc_command += ' Comment="%s"' % comment[:60]
         if confirmed:
             if 30 <= int(confirmed) <= 300:
                 rpc_command += ' Confirmed="%d"' % int(confirmed)

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -589,7 +589,7 @@ class IOSXR(object):
             if len(comment) <= 60:
                 rpc_command += ' Comment="%s"' % comment
             else:
-                raise InvalidInputError('comment needs to be shorter than 60 characters', self)
+                raise InvalidInputError('comment should be no more than 60 characters', self)
         if confirmed:
             if 30 <= int(confirmed) <= 300:
                 rpc_command += ' Confirmed="%d"' % int(confirmed)


### PR DESCRIPTION
Raise an InvalidInputError when the commit message is longer than 60 characters, as this breaks IOS-XR.