### PR TITLE
Fix installation issue with pip 10, test on py3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - 2.7
 - 3.4
 - 3.5
+- 3.6
 install:
 - pip install -r requirements-dev.txt
 - pip install -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,10 @@
 # the License.
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
-import uuid
 
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-install_reqs = parse_requirements('requirements.txt', session=uuid.uuid1())
 
-# reqs is a list of requirement
-# e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-reqs = [str(ir.req) for ir in install_reqs]
+with open("requirements.txt", "r") as fs:
+    reqs = [r for r in fs.read().splitlines() if (len(r) > 0 and not r.startswith("#"))]
 
 version = '0.52'
 


### PR DESCRIPTION
As pip 10 has been released the current setup.py doesn't work. This PR fixes that issue and also adds Python 3.6 to the tests.