### PR TITLE
Update imports to point to relocated netmiko exceptions module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It is now maintained by Mircea Ulinic [@mirceaulinic](https://github.com/mirceau
 Requirements
 =============
 
-* netmiko >= 0.5.2
+* netmiko >= 4.0.0
 * lxml >= 3.4.2
 
 * IOS-XR >= 5.1.0

--- a/pyIOSXR/iosxr.py
+++ b/pyIOSXR/iosxr.py
@@ -26,8 +26,8 @@ from xml.sax.saxutils import escape as escape_xml
 # third party lib
 from lxml import etree as ET
 from netmiko import ConnectHandler
-from netmiko.ssh_exception import NetMikoTimeoutException
-from netmiko.ssh_exception import NetMikoAuthenticationException
+from netmiko.exceptions import NetMikoTimeoutException
+from netmiko.exceptions import NetMikoAuthenticationException
 
 # local modules
 from pyIOSXR.exceptions import LockError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-netmiko>=1.4.3
+netmiko>=4.0.0
 lxml>=3.2.4


### PR DESCRIPTION
In Netmiko 4.0.0 exceptions were moved from netmiko.ssh_exception to netmiko.exceptions.

See https://github.com/ktbyers/netmiko/releases/tag/v4.0.0 for more details